### PR TITLE
fix PVE003

### DIFF
--- a/contracts/bridge/library/MultiStore.sol
+++ b/contracts/bridge/library/MultiStore.sol
@@ -38,7 +38,7 @@ library MultiStore {
         return
             Utils.merkleInnerHash( // [AppHash]
                 Utils.merkleInnerHash( // [I14]
-                    self.authToFeeGrantStoresMerkleHash, // [I10]
+                    self.authToFeeGrantStoresMerkleHash, // [I12]
                     Utils.merkleInnerHash( // [I13]
                         Utils.merkleInnerHash( // [I10]
                             self.govToIbcCoreStoresMerkleHash, // [I4]


### PR DESCRIPTION
![IMAGE 2565-09-19 13:31:19](https://user-images.githubusercontent.com/12705423/190964571-88c22b64-f257-4e6f-b46b-f7a51e2def86.jpg)
![IMAGE 2565-09-19 13:31:26](https://user-images.githubusercontent.com/12705423/190964592-5d30e4c2-85c6-49fd-8e25-df696baca602.jpg)
![IMAGE 2565-09-19 13:31:31](https://user-images.githubusercontent.com/12705423/190964612-644fe0a6-e82b-41a0-9f78-9e3f8e602514.jpg)
![IMAGE 2565-09-19 13:31:34](https://user-images.githubusercontent.com/12705423/190964624-dc56c386-40de-4901-887a-c5aefe689c8c.jpg)


PVE001: We have decided not to emit an event because we can keep track of the entire validators set using the on-chain query function. So, I think no need to emit an event because it would increase the gas.

PVE003: I will fix this. 

PVE004: For the Bridge's owner, we will use EOA for the test networks and Gnosis multi-sig wallet for the main networks.

Q1: We are using encode Int32 here because we follow the implementation in the Cosmos.
